### PR TITLE
wrong command in documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,7 +39,7 @@ These instructions will explain how to use the basic directus-migrator command a
 No installation neccessary. just run the following command from within the project root
 
 ```sh
-npx directus-migrator -init
+npx directus-migrator --init
 ```
 
 ![cli-init](https://user-images.githubusercontent.com/10267569/233826675-6936664f-e11f-49a3-8c1f-2391e83e6d1b.jpg)


### PR DESCRIPTION
When trying to follow the documentation and copy the command shown I get the following error because the command is missing a `-`.



```
/Users/username/.npm/_npx/2f9ed6e235e43e28/node_modules/command-line-args/dist/index.js:1202
        throw err
        ^

ALREADY_SET: Singular option already set [init=true]
    at FlagOption._set (/Users/username/.npm/_npx/2f9ed6e235e43e28/node_modules/command-line-args/dist/index.js:1198:21)
    at FlagOption.set (/Users/username/.npm/_npx/2f9ed6e235e43e28/node_modules/command-line-args/dist/index.js:1182:10)
    at FlagOption.set (/Users/username/.npm/_npx/2f9ed6e235e43e28/node_modules/command-line-args/dist/index.js:1245:11)
    at commandLineArgs (/Users/username/.npm/_npx/2f9ed6e235e43e28/node_modules/command-line-args/dist/index.js:1392:14)
    at Object.<anonymous> (/Users/username/.npm/_npx/2f9ed6e235e43e28/node_modules/directus-migrator/bin/commands.config.js:95:14)
    at Module._compile (node:internal/modules/cjs/loader:1255:14)
    at Module._extensions..js (node:internal/modules/cjs/loader:1309:10)
    at Module.load (node:internal/modules/cjs/loader:1113:32)
    at Module._load (node:internal/modules/cjs/loader:960:12)
    at Module.require (node:internal/modules/cjs/loader:1137:19) {
  value: true,
  optionName: 'init'
}

Node.js v20.2.0
```
